### PR TITLE
POD error

### DIFF
--- a/lib/Cache/Memcached/AnyEvent.pm
+++ b/lib/Cache/Memcached/AnyEvent.pm
@@ -612,7 +612,7 @@ Contribution is welcome, but please make sure to follow this guideline:
 =item Please send changes AND tests.
 
 In case of changes that supposedly fixes incorrect behavior, you MUST provide
-me with a E<failing test case>. How should we know if you were hallucinating or just plain stupid if you can't reproduce it yourself?
+me with a B<failing test case>. How should we know if you were hallucinating or just plain stupid if you can't reproduce it yourself?
 
 =item Please send code, not an essay.
 


### PR DESCRIPTION
perldoc threw an error for the encoding tag

`Around line 614:
           Unknown E content in E<failing test case>`
