### PR TITLE
handle memory leak by weakening reference

### DIFF
--- a/lib/Cache/Memcached/AnyEvent.pm
+++ b/lib/Cache/Memcached/AnyEvent.pm
@@ -12,6 +12,7 @@ use AnyEvent::Handle;
 use AnyEvent::Socket;
 use Carp;
 use Storable ();
+use Scalar::Util 'weaken';
 
 use constant +{
     HAVE_ZLIB => eval { require Compress::Zlib; 1 },
@@ -235,6 +236,7 @@ sub get_handle { shift->{_server_handles}->{ $_[0] } }
     foreach my $method ( qw( get get_multi ) ) {
         $installer->( $method, sub {
             my ($self, $keys, $cb) = @_;
+            weaken($self);
             $self->_push_queue( $self->protocol->$method($self, $keys, $cb) );
         } );
     }
@@ -244,6 +246,7 @@ sub get_handle { shift->{_server_handles}->{ $_[0] } }
             my ($self, @args) = @_;
             my $cb = pop @args if (ref $args[-1] eq 'CODE' or ref $args[-1] eq 'AnyEvent::CondVar');
             my ($key, $value, $initial) = @args;
+            weaken($self);
             $self->_push_queue( $self->protocol->$method( $self, $key, $value, $initial, $cb ) );
         });
     }
@@ -253,6 +256,7 @@ sub get_handle { shift->{_server_handles}->{ $_[0] } }
             my ($self, @args) = @_;
             my $cb = pop @args if (ref $args[-1] eq 'CODE' or ref $args[-1] eq 'AnyEvent::CondVar');
             my ($key, $value, $exptime, $noreply) = @args;
+            weaken($self);
             $self->_push_queue( $self->protocol->$method( $self, $key, $value, $exptime, $noreply, $cb ) );
         });
     }


### PR DESCRIPTION
There is a reference to `$self` that needs to be weakened, otherwise using those associated methods causes a major memory leak. I've made sure this is the exact reason (up to 700m and climbing before the fix, a steady 20m for a good while even in stress tests after the fix).

Additional credit to @clintongormley for helping with diagnostics.
