### PR TITLE
Mjg/fix filehandle leak

### DIFF
--- a/lib/Cache/Memcached/AnyEvent.pm
+++ b/lib/Cache/Memcached/AnyEvent.pm
@@ -116,7 +116,7 @@ sub _on_tcp_connect {
     delete $self->{_is_connecting}->{$server}; # thanks, buddy
     if (! $fh) {
         # connect failed
-        warn("failed to connect to $server");
+        warn("failed to connect to $server [$!]");
 
         if ($self->{auto_reconnect} > $self->{_connect_attempts}->{ $server }++) {
             # XXX this watcher holds a reference to $self, which means

--- a/lib/Cache/Memcached/AnyEvent.pm
+++ b/lib/Cache/Memcached/AnyEvent.pm
@@ -177,6 +177,7 @@ sub connect {
 
     return if $self->{_is_connecting} || $self->{_is_connected};
     $self->disconnect();
+    delete $self->{_is_disconnecting};
 
     $self->{_is_connecting} = {};
     $self->{_active_servers} = [];
@@ -277,7 +278,7 @@ sub _push_queue {
 sub _drain_queue {
     my $self = shift;
     if (! $self->{_is_connected}) {
-        if ($self->{_is_connecting}) {
+        if ($self->{_is_connecting} or $self->{_is_disconnecting}) {
             return;
         }
         $self->connect;
@@ -320,6 +321,7 @@ sub disconnect {
     delete $self->{_is_draining};
 
     $self->{_server_handles} = {};
+    $self->{_is_disconnecting}++;
 }
 
 sub DESTROY {

--- a/t/CMAETest/ConnectFail.pm
+++ b/t/CMAETest/ConnectFail.pm
@@ -19,7 +19,11 @@ sub run {
     my $warn_called = 0;
     local $SIG{__WARN__} = sub {
 #        like( $_[0], qr/^failed to connect to $bogus_server/);
-        $warn_called++;
+        if ( $_[0] =~ /^failed to connect to $bogus_server/ ) {
+            $warn_called++;
+        } else {
+            warn @_;
+        }
     };
 
     foreach my $i (1..50) {

--- a/t/CMAETest/Consistency.pm
+++ b/t/CMAETest/Consistency.pm
@@ -45,6 +45,7 @@ warn Dumper($memd_anyevent);
 
         $cv->recv;
         $memd_anyevent->disconnect;
+        $memd->disconnect_all;
     }
     done_testing;
 }

--- a/t/CMAETest/Stats.pm
+++ b/t/CMAETest/Stats.pm
@@ -23,6 +23,7 @@ sub run {
             $cv->end;
         } );
         $cv->recv;
+        $memd->disconnect;
     }
     done_testing;
 }


### PR DESCRIPTION
On my Mac (OS X 10.9.5 Mavericks), the latest git version of CMAE was failing its tests in t/run.t at about Binary/Traditional/Storable Dorman, with _'Failed to connect to any memcached servers'_.

Displaying the actual connect error (commit 9110fe9) revealed that this was due to running out of file handles, _'failed to connect to 127.0.0.1:10005 [Too many open files]'_.

Eventually I tracked this down to servers getting reconnected during disconnect processing - in the event loop of the following test - by a call to _drain_queue(). The solution is to introduce a state **_is_disconnecting** and to test for this in _drain_queue(). (Commit c6e2257)

Tests now pass on my Mac, and a file handle leak has been closed.

(Commits 0412e97 and 2592075 are not necessary to fix this, but were part of my debugging and seem correct and appropriate to keep.)

All the best
Michael
